### PR TITLE
Import custom Vue components

### DIFF
--- a/src/cosmicds_hubble/__init__.py
+++ b/src/cosmicds_hubble/__init__.py
@@ -1,3 +1,4 @@
+import ipyvue
 from pathlib import Path
 from cosmicds import STORY_PATHS
 from .story import *
@@ -8,3 +9,12 @@ from .components import *
 
 
 STORY_PATHS['hubble'] = Path(__file__).parent / "Notebook.ipynb"
+
+# Register any custom Vue components
+comp_dir = Path(__file__).parent / "components"
+
+for comp_path in comp_dir.iterdir():
+    if comp_path.is_file and comp_path.suffix == ".vue":
+        ipyvue.register_component_from_string(
+            name=comp_path.stem.replace('_', '-'),
+            value=comp_path.read_text())


### PR DESCRIPTION
It looks like one thing that got left behind in the migration is importing custom Vue components at the Hubble story level. This PR adds that functionality back into the story's `__init__.py`.