### PR TITLE
Update number of x ticks in each viewer based on width

### DIFF
--- a/src/cosmicds_hubble/stages/stage_one.vue
+++ b/src/cosmicds_hubble/stages/stage_one.vue
@@ -199,6 +199,30 @@
 
 <script>
 module.exports = {
+  mounted() {
+    const config = { childList: true, subtree: true };
+    const onMutation = (mutationList, observer) => {
+      for (const mutation of mutationList) {
+        if (mutation.type === 'childList') {
+          const target = mutation.target;
+          const viewerName = this.viewerName(target);
+          if (viewerName !== null) {
+            const resizeObserver = new ResizeObserver((entries) => {
+              for (const entry of entries) {
+                const pixelSize = entry.devicePixelContentBoxSize[0];
+                const width = pixelSize.inlineSize;
+                const nticks = Math.floor(width / 125);
+                this.set_viewer_nticks({ nticks: nticks, axis: 'x', viewer: viewerName });
+              }
+            });
+            resizeObserver.observe(target, { box: 'device-pixel-content-box' });
+          }
+        }
+      }
+    }
+    const observer = new MutationObserver(onMutation);
+    observer.observe(this.$el, config);
+  },
   methods: {
     scrollIntoView: function(entries, observer, isIntersecting) {
       if (isIntersecting) {
@@ -207,6 +231,14 @@ module.exports = {
           block: 'center'
         });
       }
+    },
+    viewerName: function(node) {
+      for (const key of Object.keys(this.viewers)) {
+        if (node.classList.contains(key)) {
+          return key;
+        }
+      }
+      return null;
     }
   }
 }

--- a/src/cosmicds_hubble/stages/stage_three.vue
+++ b/src/cosmicds_hubble/stages/stage_three.vue
@@ -227,6 +227,30 @@
 <script>
 
 module.exports = {
+  mounted() {
+    const config = { childList: true, subtree: true };
+    const onMutation = (mutationList, observer) => {
+      for (const mutation of mutationList) {
+        if (mutation.type === 'childList') {
+          const target = mutation.target;
+          const viewerName = this.viewerName(target);
+          if (viewerName !== null) {
+            const resizeObserver = new ResizeObserver((entries) => {
+              for (const entry of entries) {
+                const pixelSize = entry.devicePixelContentBoxSize[0];
+                const width = pixelSize.inlineSize;
+                const nticks = Math.floor(width / 125);
+                this.set_viewer_nticks({ nticks: nticks, axis: 'x', viewer: viewerName });
+              }
+            });
+            resizeObserver.observe(target, { box: 'device-pixel-content-box' });
+          }
+        }
+      }
+    }
+    const observer = new MutationObserver(onMutation);
+    observer.observe(this.$el, config);
+  },
   methods: {
     scrollIntoView: function(entries, observer, isIntersecting) {
       if (isIntersecting) {
@@ -235,6 +259,14 @@ module.exports = {
           block: 'center'
         });
       }
+    },
+    viewerName: function(node) {
+      for (const key of Object.keys(this.viewers)) {
+        if (node.classList.contains(key)) {
+          return key;
+        }
+      }
+      return null;
     }
   }
 }

--- a/src/cosmicds_hubble/viewers/spectrum_view.py
+++ b/src/cosmicds_hubble/viewers/spectrum_view.py
@@ -9,6 +9,7 @@ from glue_jupyter.bqplot.scatter import BqplotScatterView, \
     BqplotScatterLayerArtist
 from traitlets import Bool
 
+from cosmicds.viewers.cds_viewers import CDSScatterView
 from ..utils import H_ALPHA_REST_LAMBDA, MG_REST_LAMBDA
 
 __all__ = ['SpectrumView', 'SpectrumViewLayerArtist', 'SpectrumViewerState']
@@ -46,7 +47,7 @@ class SpectrumViewLayerArtist(BqplotScatterLayerArtist):
                                      self.scatter]
 
 
-class SpectrumView(BqplotScatterView):
+class SpectrumView(CDSScatterView):
     _data_artist_cls = SpectrumViewLayerArtist
     _subset_artist_cls = SpectrumViewLayerArtist
 

--- a/src/cosmicds_hubble/viewers/spectrum_view.py
+++ b/src/cosmicds_hubble/viewers/spectrum_view.py
@@ -9,7 +9,7 @@ from glue_jupyter.bqplot.scatter import BqplotScatterView, \
     BqplotScatterLayerArtist
 from traitlets import Bool
 
-from cosmicds.viewers.cds_viewers import CDSScatterView
+from cosmicds.viewers.cds_viewers import cds_viewer
 from ..utils import H_ALPHA_REST_LAMBDA, MG_REST_LAMBDA
 
 __all__ = ['SpectrumView', 'SpectrumViewLayerArtist', 'SpectrumViewerState']
@@ -47,7 +47,7 @@ class SpectrumViewLayerArtist(BqplotScatterLayerArtist):
                                      self.scatter]
 
 
-class SpectrumView(CDSScatterView):
+class SpecView(BqplotScatterView):
     _data_artist_cls = SpectrumViewLayerArtist
     _subset_artist_cls = SpectrumViewLayerArtist
 
@@ -354,3 +354,6 @@ class SpectrumView(CDSScatterView):
     @property
     def line_visible(self):
         return self.user_line.visible
+
+
+SpectrumView = cds_viewer(SpecView, "SpectrumView")


### PR DESCRIPTION
This PR is a companion to https://github.com/cosmicds/cosmicds/pull/138. This PR adds functionality to stages one and three (the ones with glue viewers) to allow the number of ticks shown on each axis to change dynamically with the viewer's width. To do this, we add a `MutationObserver` to the stage. Whenever an element is added with a class that is the name of one of the stage's viewers, the mutation observer adds a `ResizeObserver` to that element. The resize observer then updates the number of ticks for that viewer as the size changes. Currently, I've set the number of ticks to be the pixel width of the viewer divided by 125.

